### PR TITLE
Add Test for 441-A6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 target/
-
+test-output/
 *.iml
 /bin
 /.settings

--- a/src/main/java/org/javamoney/tck/tests/ExternalizingNumericValueTest.java
+++ b/src/main/java/org/javamoney/tck/tests/ExternalizingNumericValueTest.java
@@ -1287,7 +1287,7 @@ public class ExternalizingNumericValueTest{
 
     /**
      * Check if a correct double value is returned, truncation is
-     allowed to be performed (but is not necessary).
+     * allowed to be performed (but is not necessary).
      */
     @SpecAssertion(section = "4.2.3", id = "423-C8")
     @Test


### PR DESCRIPTION
Adds the missing test for 441-A6. The test currently fails in the RI
for locales with a trailing zero (eg "3.5-") because
`DefaultMonetaryAmountFormat.positiveTokens` parses successfully and
`DefaultMonetaryAmountFormat.negativeTokens` is never used.
