### PR TITLE
Add CurrencyUnit hashCode checks

### DIFF
--- a/src/main/java/org/javamoney/tck/tests/ModellingCurrenciesTest.java
+++ b/src/main/java/org/javamoney/tck/tests/ModellingCurrenciesTest.java
@@ -16,6 +16,8 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
+import javax.money.CurrencyContext;
+import javax.money.CurrencyQueryBuilder;
 import javax.money.CurrencyUnit;
 import javax.money.Monetary;
 import java.util.ArrayList;
@@ -122,6 +124,12 @@ public class ModellingCurrenciesTest {
         }
         for (int i = 0; i < firstUnits.size(); i++) {
             AssertJUnit.assertEquals(firstUnits.get(i), secondUnits.get(i));
+        }
+        for (CurrencyUnit unit : Monetary.getCurrencies(CurrencyQueryBuilder.of().build())) {
+            String currencyCode = unit.getCurrencyCode();
+            if (currencyCode != null) {
+                AssertJUnit.assertEquals("CurrencyUnit#hashCode() must be equal to currency code hash code", unit.hashCode(), currencyCode.hashCode());
+            }
         }
     }
 


### PR DESCRIPTION
The CurrencyUnit class comment specifies equality in terms of
to have the same hash code the case code needs to be equal to the hash
code of the currency code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-tck/22)
<!-- Reviewable:end -->
