### PR TITLE
Remove java.net references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,24 +57,17 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>JSR354 Issues List</name>
-			<subscribe>https://java.net/projects/javamoney/lists</subscribe>
-			<unsubscribe>https://java.net/projects/javamoney/lists</unsubscribe>
-			<archive>https://java.net/projects/javamoney/lists/issues/archive</archive>
-			<post>issues@javamoney.java.net</post>
-		</mailingList>
-		<mailingList>
 			<name>JSR354 Public Mailing List</name>
-			<subscribe>https://java.net/projects/javamoney/lists</subscribe>
-			<unsubscribe>https://java.net/projects/javamoney/lists</unsubscribe>
-			<archive>http://java.net/projects/javamoney/lists/jcurrency_mail/archive</archive>
-			<post>jcurrency_mail@javamoney.java.net</post>
+			<subscribe>javamoney+subscribe@groups.io</subscribe>
+			<unsubscribe>javamoney+unsubscribe@groups.io</unsubscribe>
+			<archive>https://groups.io/g/javamoney/topics</archive>
+			<post>javamoney@groups.io</post>
 		</mailingList>
 	</mailingLists>
 
 	<issueManagement>
-		<system>JIRA</system>
-		<url>http://java.net/jira/browse/JAVAMONEY</url>
+		<system>GITHUB</system>
+		<url>https://github.com/JavaMoney/jsr354-tck/issues</url>
 	</issueManagement>
 
 	<prerequisites>

--- a/src/main/asciidoc/userguide.adoc
+++ b/src/main/asciidoc/userguide.adoc
@@ -48,7 +48,7 @@ correctly and help to ensure also behavioural interoperability between different
 TCK for JSR 354 Money and Currency ensures exactly this for implementations of the Money & Currency JSR.
 The TCK hereby is open sourced under the Apache 2 licence. Nevertheless we would be highly interested to keep track of
 implementation of this JSR. So if you are are planning or even writing on an implementation of this JSR, drop a mail to
-the JSR's mailto:jcurrency_mail@javamoney.java.net[mailing list] on http://java.net/project/JavaMoney[java.net] or the
+the JSR's mailto:javamoney@groups.io[mailing list] on https://groups.io/g/javamoney/[groups.io] or the
 JSR's mailto:atsticks@java.net[spec lead].
 
 


### PR DESCRIPTION
Removes the java.net references from the POM and user guide.

The spec leads mail still points to java.net, I don't know which one
we wants to use instead.

Fixes #17

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-tck/24)
<!-- Reviewable:end -->
