### PR TITLE
Switch build to OpenJDK 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+dist: trusty
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
 
 after_success:
   - mvn deploy -Dmaven.test.skip -s settings.xml


### PR DESCRIPTION
Oracle no longer provided updates for Java which causes some builds to
fail like #21.
However from other vendors JDK 7 updates are still available.

Fixes  #23

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/jsr354-tck/25)
<!-- Reviewable:end -->
